### PR TITLE
プロダクト　細かいデザイン調整

### DIFF
--- a/src/features/ProductsCarousel/presentations/index.module.scss
+++ b/src/features/ProductsCarousel/presentations/index.module.scss
@@ -19,9 +19,10 @@
 
 .embla__viewport {
   width: 60%;
+  padding: 0;
   @media (max-width: $mobile) {
     width: 360px;
-    height: 500px;
+    height: 530px;
     overflow: hidden;
   }
 }

--- a/src/features/SelectProduction/presentations/index.tsx
+++ b/src/features/SelectProduction/presentations/index.tsx
@@ -39,6 +39,7 @@ export const SelectProductionPresentation: React.FC<Props> = ({
               web_href={product.web_href}
               app_href={product.app_href}
               google_href={product.google_href}
+              git_href={product.git_href}
               tags={product.tags}
             />
           </div>

--- a/src/ui/ProductDetailItem/index.module.scss
+++ b/src/ui/ProductDetailItem/index.module.scss
@@ -68,18 +68,16 @@
   position: absolute;
   right: 20px;
   bottom: 110px;
-  width: 120px;
+  width: 180px;
   text-align: end;
   font-family: "Abel", sans-serif;
-  font-size: $text-2xl;
+  font-size: $text-xl;
   @media (max-width: $mobile) {
     right: 10px;
     bottom: 0px;
     top: 40px;
-    width: 180px;
     height: 50px;
     text-align: center;
-    font-size: $text-2xl;
   }
 }
 

--- a/src/ui/ProductDetailItem/index.module.scss
+++ b/src/ui/ProductDetailItem/index.module.scss
@@ -8,10 +8,10 @@
   background-color: var(--product-background-color);
   z-index: 0;
   font-family: "Abel", "Zen Kaku Gothic New", sans-serif;
-
+  margin: 0;
   @media (max-width: $mobile) {
     width: 340px;
-    height: 490px;
+    height: 500px;
   }
 }
 
@@ -73,10 +73,13 @@
   font-family: "Abel", sans-serif;
   font-size: $text-2xl;
   @media (max-width: $mobile) {
-    right: 50px;
+    right: 10px;
     bottom: 0px;
     top: 40px;
-    text-align: start;
+    width: 180px;
+    height: 50px;
+    text-align: center;
+    font-size: $text-2xl;
   }
 }
 
@@ -93,7 +96,7 @@
   @media (max-width: $mobile) {
     text-align: left;
     position: absolute;
-    right: 20px;
+    right: 15px;
     bottom: 0;
     top: 50px;
   }
@@ -137,10 +140,15 @@
 
 .context_text_right {
   margin: 0 10px;
+  display: flex;
+  flex-direction: column;
+  @media (max-width: $mobile) {
+    margin-bottom: 16.5px;
+  }
 }
 
 .release {
-  color: red;
+  color: #f1f1f1;
 }
 
 .main_description {
@@ -150,14 +158,16 @@
   overflow-wrap: break-word;
 }
 
+.link_context {
+  margin-top: auto;
+}
 .link {
   color: #f1f1f1;
-  border-bottom: 1px solid #f1f1f1;
+  text-decoration: underline;
   width: fit-content;
 }
 
 .git {
   color: #f1f1f1;
-  border-bottom: 1px solid #f1f1f1;
-  width: fit-content;
+  display: flex;
 }

--- a/src/ui/ProductDetailItem/index.tsx
+++ b/src/ui/ProductDetailItem/index.tsx
@@ -12,6 +12,8 @@ type Props = {
 };
 
 export const ProductDetailItem: React.FC<Props> = ({ product }) => {
+  const targetProps = { target: "_blank", rel: "noopener noreferrer" };
+
   return (
     <>
       <Color key={product.id} src={product.image} format="rgbArray">
@@ -25,7 +27,6 @@ export const ProductDetailItem: React.FC<Props> = ({ product }) => {
                 ></div>
                 <div className={styles.context}>
                   <div className={styles.context_left}>
-                    {/* <div className={styles.number}>{number}</div> */}
                     <div className={styles.square}></div>
                     <Image
                       className={styles.product_image}
@@ -50,7 +51,6 @@ export const ProductDetailItem: React.FC<Props> = ({ product }) => {
                     <div className={styles.decoration_number}>1 2 3 4 5 6 7 8 9 10 11</div>
                     <div className={styles.context_text_right}>
                       <div className={styles.detail}>
-                        {" "}
                         {Array.isArray(product.release_date) && (
                           <div className={styles.release}>
                             <Text richText={product.release_date} />
@@ -61,25 +61,29 @@ export const ProductDetailItem: React.FC<Props> = ({ product }) => {
                             <Text richText={product.detail} />
                           </div>
                         )}
+                      </div>
+                      <div className={styles.link_context}>
                         {product.web_href && (
-                          <Link href={product.web_href}>
-                            <div className={styles.link}>webllinkはこちら</div>
+                          <Link href={product.web_href} {...targetProps}>
+                            <div className={styles.link}>web site</div>
                           </Link>
                         )}
                         {product.app_href && (
-                          <Link href={product.app_href}>
-                            <div className={styles.link}>appllinkはこちら</div>
+                          <Link href={product.app_href} {...targetProps}>
+                            <div className={styles.link}>app store</div>
                           </Link>
                         )}
                         {product.google_href && (
-                          <Link href={product.google_href}>
-                            <div className={styles.link}>googlelinkはこちら</div>
+                          <Link href={product.google_href} {...targetProps}>
+                            <div className={styles.link}>play store</div>
                           </Link>
                         )}
                         {product.git_href && (
-                          <Link href={product.git_href}>
+                          <Link href={product.git_href} {...targetProps}>
                             <div className={styles.git}>
-                              void let&#0039;s see &#40;&#41; &#0061;&#0062; github
+                              <div>void let&#0039;s see &#40;&#41; &#0061;&#0062;</div>
+                              <pre>&#009;&#009;</pre>
+                              <div className={styles.link}>github</div>
                             </div>
                           </Link>
                         )}

--- a/src/ui/Production/index.module.scss
+++ b/src/ui/Production/index.module.scss
@@ -6,6 +6,8 @@
   width: 352px;
   height: 456px;
   align-items: center;
+  border-radius: $rounded-lg;
+  box-shadow: $shadow-sm;
 }
 
 .item_context {
@@ -16,6 +18,8 @@
   width: 352px;
   height: 200px;
   object-fit: cover;
+  border-top-left-radius: $rounded-lg;
+  border-top-right-radius: $rounded-lg;
 }
 
 .title {

--- a/src/ui/Production/index.module.scss
+++ b/src/ui/Production/index.module.scss
@@ -4,7 +4,7 @@
   background-color: $white;
   padding: 0;
   width: 352px;
-  height: 456px;
+  min-height: 456px;
   align-items: center;
   border-radius: $rounded-lg;
   box-shadow: $shadow-sm;
@@ -30,6 +30,10 @@
 .text {
   padding: 16px 0;
   font-size: $text-base;
+}
+
+.moreButton {
+  border-bottom: 1px solid $black;
 }
 
 .tag {

--- a/src/ui/Production/index.module.scss
+++ b/src/ui/Production/index.module.scss
@@ -4,7 +4,7 @@
   background-color: $white;
   padding: 0;
   width: 352px;
-  min-height: 456px;
+  height: 100%;
   align-items: center;
   border-radius: $rounded-lg;
   box-shadow: $shadow-sm;

--- a/src/ui/Production/index.stories.tsx
+++ b/src/ui/Production/index.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<T> = {
     web_href: { control: "text" },
     app_href: { control: "text" },
     google_href: { control: "text" },
+    git_href: { control: "text" },
   },
 };
 
@@ -45,5 +46,6 @@ export const Default: Story = {
     web_href: "https://www.google.com/",
     app_href: "https://www.google.com/",
     google_href: "https://www.google.com/",
+    git_href: "https://www.google.com/",
   },
 };

--- a/src/ui/Production/index.tsx
+++ b/src/ui/Production/index.tsx
@@ -70,7 +70,7 @@ export const Production: React.FC<Props> = ({
               />
             )}
             {git_href && (
-              <IconLink href={git_href} text="Git Hub" icon={FaGithub} size="s" openInNewTab />
+              <IconLink href={git_href} text="GitHub" icon={FaGithub} size="s" openInNewTab />
             )}
           </div>
         </div>

--- a/src/ui/Production/index.tsx
+++ b/src/ui/Production/index.tsx
@@ -5,8 +5,8 @@ import { FaApple } from "react-icons/fa";
 import { FaGooglePlay } from "react-icons/fa";
 import { FaGithub } from "react-icons/fa";
 import { RichText } from "@/types/block";
-import { BlackText } from "@/utils/blackText/blackText";
 import styles from "./index.module.scss";
+import { RenderText } from "./logics";
 import { IconLink } from "../IconLink";
 
 export type Props = {
@@ -42,11 +42,7 @@ export const Production: React.FC<Props> = ({
       <div className={styles.item_context}>
         <div className={styles.context}>
           <div className={styles.title}>{title}</div>
-          {Array.isArray(text) && (
-            <div className={styles.text}>
-              <BlackText richText={text} />
-            </div>
-          )}
+          {Array.isArray(text) && <div className={styles.text}>{RenderText(text)}</div>}
           <div className={styles.tag}>
             {web_href && (
               <IconLink

--- a/src/ui/Production/index.tsx
+++ b/src/ui/Production/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { FaApple } from "react-icons/fa";
 import { FaGooglePlay } from "react-icons/fa";
+import { FaGithub } from "react-icons/fa";
 import { RichText } from "@/types/block";
 import { BlackText } from "@/utils/blackText/blackText";
 import styles from "./index.module.scss";
@@ -17,14 +18,15 @@ export type Props = {
   web_href?: string | null;
   app_href?: string | null;
   google_href?: string | null;
+  git_href?: string | null;
 };
 
 export type ProductionDetailProps = Props & {
   description: RichText[];
   release_date?: RichText[];
   detail?: RichText[];
-  git_href?: string | null;
 };
+
 export const Production: React.FC<Props> = ({
   image,
   title,
@@ -32,6 +34,7 @@ export const Production: React.FC<Props> = ({
   web_href,
   app_href,
   google_href,
+  git_href,
 }) => {
   return (
     <div className={styles.wrapper}>
@@ -65,6 +68,9 @@ export const Production: React.FC<Props> = ({
                 size="s"
                 openInNewTab
               />
+            )}
+            {git_href && (
+              <IconLink href={git_href} text="Git Hub" icon={FaGithub} size="s" openInNewTab />
             )}
           </div>
         </div>

--- a/src/ui/Production/logics/index.tsx
+++ b/src/ui/Production/logics/index.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import { RichText } from "@/types/block";
+import styles from "./../index.module.scss";
+
+export const RenderText = (text: RichText[]) => {
+  const toggleExpand = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // textの正規化
+  let textAsString = "";
+  text.map((value: RichText) => {
+    const { text } = value;
+    if (!text) return null;
+    textAsString += text.content;
+  });
+
+  if (!isExpanded) {
+    // 展開されていない場合、最初の70文字と「もっと見る」ボタンを表示
+    return (
+      <>
+        {textAsString.length > 70 ? textAsString.substring(0, 70) + "　..." : textAsString}
+        {textAsString.length > 70 && (
+          <button onClick={toggleExpand} className={styles.moreButton}>
+            もっと見る
+          </button>
+        )}
+      </>
+    );
+  } else {
+    // 展開されている場合、全テキストと「閉じる」ボタンを表示
+    return (
+      <>
+        {textAsString}
+        <button onClick={toggleExpand} className={styles.moreButton}>
+          閉じる
+        </button>
+      </>
+    );
+  }
+};

--- a/src/ui/Production/logics/index.tsx
+++ b/src/ui/Production/logics/index.tsx
@@ -3,41 +3,24 @@ import { RichText } from "@/types/block";
 import styles from "./../index.module.scss";
 
 export const RenderText = (text: RichText[]) => {
+  const [isExpanded, setIsExpanded] = useState(false);
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
   };
 
-  const [isExpanded, setIsExpanded] = useState(false);
-
   // textの正規化
-  let textAsString = "";
-  text.map((value: RichText) => {
-    const { text } = value;
-    if (!text) return null;
-    textAsString += text.content;
-  });
+  const textAsString = text.reduce((acc, { text }) => (text ? acc + text.content : acc), "");
 
-  if (!isExpanded) {
-    // 展開されていない場合、最初の70文字と「もっと見る」ボタンを表示
-    return (
-      <>
-        {textAsString.length > 70 ? textAsString.substring(0, 70) + "　..." : textAsString}
-        {textAsString.length > 70 && (
-          <button onClick={toggleExpand} className={styles.moreButton}>
-            もっと見る
-          </button>
-        )}
-      </>
-    );
-  } else {
-    // 展開されている場合、全テキストと「閉じる」ボタンを表示
-    return (
-      <>
-        {textAsString}
+  return (
+    <>
+      {textAsString.length > 70 && !isExpanded
+        ? `${textAsString.substring(0, 70)}　...`
+        : textAsString}
+      {textAsString.length > 70 && (
         <button onClick={toggleExpand} className={styles.moreButton}>
-          閉じる
+          {isExpanded ? "閉じる" : "もっと見る"}
         </button>
-      </>
-    );
-  }
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
## 関連issue
#107 

## やったこと
### 
**ProductionDetail**
- 各リンクを_brankをつけて別タブで開くように
- release デフォルト白色に変更
- Detailはweb site, app store, play store, githubに変更
    - リンクは下詰め
- responsive崩れ修正

**Production**
- GitHubのオレンジ色のボタンを追加
- プロダクトアイテムの角を丸めた
- box-shadowをつけた(variables.scssにある一番小さいやつ)


<img width="1489" alt="スクリーンショット 2024-06-22 16 50 20" src="https://github.com/jack-app/jackweb3/assets/131859320/f810cff6-4b4e-46f2-85fb-02786f6cb4c0">


<img width="716" alt="スクリーンショット 2024-06-22 17 05 07" src="https://github.com/jack-app/jackweb3/assets/131859320/dffba92e-2dd9-4d6a-9d01-d1380c4395ff">
