### PR TITLE
blog　細かいデザイン修正

### DIFF
--- a/src/screens/BlogArticle/index.module.scss
+++ b/src/screens/BlogArticle/index.module.scss
@@ -24,6 +24,9 @@
   width: 100%;
   max-width: calc(848px + 260px + 16px);
   margin-bottom: 32px;
+  @media (max-width: $mobile) {
+    margin-left: 2rem;
+  }
 }
 
 .suggestedArticleListContainer {

--- a/src/ui/ArticleItem/index.module.scss
+++ b/src/ui/ArticleItem/index.module.scss
@@ -1,4 +1,4 @@
-@use '@/styles/variables' as *;
+@use "@/styles/variables" as *;
 
 .wrapper {
   position: relative;
@@ -16,6 +16,7 @@
     border-radius: 8px 8px 0 0;
     width: 360px;
     height: 200px;
+    object-fit: cover;
   }
 
   .descriptionWrapper {
@@ -34,7 +35,7 @@
       font-weight: bold;
 
       .link::before {
-        content: '';
+        content: "";
         position: absolute;
         top: 0;
         bottom: 0;


### PR DESCRIPTION
## 関連issue
#107 
## やったこと

### ブログ
- 画像が引き伸ばされるのではなく切り取りにした
- ### ブログ詳細
- 画面幅を小さくした時に左端に余白がなくなるので入れた
<img width="433" alt="スクリーンショット 2024-06-22 20 00 02" src="https://github.com/jack-app/jackweb3/assets/131859320/6596e69b-5d2c-4509-8984-4c5813f60ea6">
<img width="490" alt="スクリーンショット 2024-06-22 20 00 19" src="https://github.com/jack-app/jackweb3/assets/131859320/78b5c150-2688-4394-a9a1-5b5b3adf3993">
