### PR TITLE
画像が表示されないものがあるバグを修正

### DIFF
--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { Image as ImageBlock } from "@/types/block";
 
 type Props = {
@@ -20,7 +19,8 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
         // eslint-disable-next-line @next/next/no-img-element
         <img src={src} alt={caption} width={500} height={500} />
       ) : (
-        <Image src={src} alt={caption} width={500} height={500} />
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt={caption} width={500} height={500} />
       )}
       {caption && <figcaption>{caption}</figcaption>}
     </figure>

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -17,9 +17,9 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
   return (
     <figure className="mx-auto">
       {image.type === "external" ? (
-        <Image src={src} alt={caption} width={500} height={500} />
+        <img src={src} alt={caption} width={500} height={500} />
       ) : (
-        <Image src={src} alt={caption} width={500} height={500} />
+        <img src={src} alt={caption} width={500} height={500} />
       )}
       {caption && <figcaption>{caption}</figcaption>}
     </figure>

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { Image as ImageBlock } from "@/types/block";
 
 type Props = {

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Image as ImageBlock } from "@/types/block";
 
 type Props = {
@@ -16,11 +17,9 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
   return (
     <figure className="mx-auto">
       {image.type === "external" ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={src} alt={caption} width={500} height={500} />
+        <Image src={src} alt={caption} width={500} height={500} />
       ) : (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={src} alt={caption} width={500} height={500} />
+        <Image src={src} alt={caption} width={500} height={500} />
       )}
       {caption && <figcaption>{caption}</figcaption>}
     </figure>

--- a/src/pages/blog/[id]/index.tsx
+++ b/src/pages/blog/[id]/index.tsx
@@ -71,13 +71,24 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
 
     if (type === "column_list") {
       if (!block.children) return block;
-      const childBlocks = await Promise.all(
-        block.children.map(async (column) => await filterBlocks(column)),
+
+      const columnList = await Promise.all(
+        block.children.map(async (column) => {
+          if (!column.children) return column;
+          const childBlocks = await Promise.all(
+            column.children.map(async (child) => await filterBlocks(child)),
+          );
+
+          return {
+            ...column,
+            children: childBlocks,
+          };
+        }),
       );
 
       filteredBlock = {
         ...block,
-        children: childBlocks,
+        children: columnList,
       };
     }
 

--- a/src/pages/blog/[id]/index.tsx
+++ b/src/pages/blog/[id]/index.tsx
@@ -62,8 +62,8 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
       ? page.properties.Publish_Date.date.start
       : page.created_time.slice(0, 10),
   } as PageInfo;
-  // 画像生成ではNode.jsの機能を使うため、サーバー上で処理されるgetStaticProps内で行う
 
+  // 画像生成ではNode.jsの機能を使うため、サーバー上で処理されるgetStaticProps内で行う
   const filterBlocks = async (block: Block) => {
     const { type, id } = block;
 
@@ -72,19 +72,12 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
     if (type === "column_list") {
       if (!block.children) return block;
       const childBlocks = await Promise.all(
-        block.children.map(async (column) => {
-          const childBlocks = await Promise.all(
-            column.children
-              ? column.children.map(async (childBlock) => filterBlocks(childBlock))
-              : [],
-          );
-          return childBlocks;
-        }),
+        block.children.map(async (column) => await filterBlocks(column)),
       );
 
       filteredBlock = {
         ...block,
-        children: childBlocks.flat(),
+        children: childBlocks,
       };
     }
 

--- a/src/ui/ArticleItem/index.tsx
+++ b/src/ui/ArticleItem/index.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 import styles from "./index.module.scss";
@@ -15,13 +14,7 @@ export type Props = {
 export const ArticleItem: React.FC<Props> = ({ id, image, date, title, tags }) => {
   return (
     <article className={styles.wrapper}>
-      <Image
-        src={image ? image : ""}
-        alt={title}
-        width={360}
-        height={189}
-        className={styles.image}
-      />
+      <img src={image ? image : ""} alt={title} width={360} height={189} className={styles.image} />
       <div className={styles.descriptionWrapper}>
         <span className={styles.date}>{date}</span>
         <h3 className={styles.title}>


### PR DESCRIPTION
## 関連issue
#129 

## やったこと

### 原因

画像が横並びになっている時に、画像が表示されなくなる。

横並びになっているビューは、Notionのcolumnという機能を使っており、再帰的にブロックを処理する必要がある。画像の生成をcolumn内にある画像に対して行なっていなかったため、Notionの画像の期限問題が発生して表示されない。

### 解決策

column内の画像に対しても画像の生成を行う
