### PR TITLE
blogのWriterからnext/imageを引き剝がした 

### DIFF
--- a/src/ui/Writer/index.tsx
+++ b/src/ui/Writer/index.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image"; // Import the Image component from next/image
 import Link from "next/link";
 import React from "react";
 import styles from "./index.module.scss";
@@ -13,13 +12,13 @@ export const Writer: React.FC<Props> = ({ writerName, writerImage, isLink = fals
   return isLink ? (
     <Link href={`/blog/writer/${writerName}`}>
       <div className={styles.link}>
-        <Image className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
+        <img className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
         <span className={styles.name}>{writerName}</span>
       </div>
     </Link>
   ) : (
     <div className={styles.writer}>
-      <Image className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
+      <img className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
       <span className={styles.name}>{writerName}</span>
     </div>
   );


### PR DESCRIPTION
## 関連issue
#134 
## やったこと
vercelの画像最適化上限をこえてしまっていたため、画像が表示されなくなっていた。
next/imageを使用しないようにしました。