### PR TITLE
メンバー画像の大きさの違いを修正

### DIFF
--- a/src/screens/Top/index.module.scss
+++ b/src/screens/Top/index.module.scss
@@ -369,10 +369,10 @@
   .membersList {
     display: flex;
     justify-content: center;
-    padding: 100px 0;
+    padding: 16px 0 70px;
     gap: 36px;
     @media screen and (max-width: $mobile) {
-      padding: 60px 0;
+      padding: 16px 0 60px;
       gap: 8px;
     }
   }
@@ -394,6 +394,10 @@
     width: 100%;
     max-width: 200px;
     height: 200px;
+    @media screen and (max-width: $mobile) {
+      max-width: 100px;
+      height: 100px;
+    }
   }
 
   .memberImage {

--- a/src/screens/Top/index.module.scss
+++ b/src/screens/Top/index.module.scss
@@ -369,10 +369,10 @@
   .membersList {
     display: flex;
     justify-content: center;
-    padding: 40px 0;
+    padding: 100px 0;
     gap: 36px;
     @media screen and (max-width: $mobile) {
-      padding: 16px 0;
+      padding: 60px 0;
       gap: 8px;
     }
   }
@@ -389,6 +389,19 @@
       text-align: start;
     }
   }
+
+  .membersImage {
+    width: 100%;
+    max-width: 200px;
+    height: 200px;
+  }
+
+  .memberImage {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+  }
+
   .membersName {
     font-size: $text-3xl;
     text-align: center;

--- a/src/screens/Top/index.tsx
+++ b/src/screens/Top/index.tsx
@@ -254,8 +254,14 @@ export const TopScreen: React.FC<Props> = ({ articles, product }) => {
           </p>
           <div className={styles.membersList}>
             {memberStories.map((member) => (
-              <div key={member.name}>
-                <Image src={member.image} alt={member.name} width={200} height={200} />
+              <div key={member.name} className={styles.membersImage}>
+                <Image
+                  src={member.image}
+                  alt={member.name}
+                  width={200}
+                  height={200}
+                  className={styles.memberImage}
+                />
                 <p className={styles.membersName}>{member.name}</p>
               </div>
             ))}


### PR DESCRIPTION
## 関連issue
close #147 
## やったこと
トップのメンバー画像の大きさが違うところを直しました！
レスポンシブも対応してます

多分すけの画像が小さく言えるのは画像自体に影っぽいのがあるみたい？？？

<img width="453" alt="スクリーンショット 2025-04-02 21 13 46" src="https://github.com/user-attachments/assets/be3e45e8-478e-41a1-a19c-fe3f4198a2ef" />
<img width="1280" alt="スクリーンショット 2025-04-02 21 13 59" src="https://github.com/user-attachments/assets/1f5cdafd-fb42-4753-b75b-4a149ec7cc82" />

