### PR TITLE
ヘッダーのリンク順をトップページにそろえた

### DIFF
--- a/src/ui/Header/index.tsx
+++ b/src/ui/Header/index.tsx
@@ -26,23 +26,23 @@ export const Header: React.FC<Props> = () => {
       </Link>
       <div className={styles.right}>
         <nav className={styles.nav}>
-          <Link href="/products" onClick={closeMenu} className={styles.hamburgerNavName}>
-            プロダクト
+          <Link href="/activities" onClick={closeMenu} className={styles.hamburgerNavName}>
+            活動内容
           </Link>
           <Link href="/members" onClick={closeMenu} className={styles.hamburgerNavName}>
             メンバー
           </Link>
-          <Link href="/activities" onClick={closeMenu} className={styles.hamburgerNavName}>
-            活動内容
+          <Link href="/products" onClick={closeMenu} className={styles.hamburgerNavName}>
+            プロダクト
+          </Link>
+          <Link href="/blog" onClick={closeMenu} className={styles.hamburgerNavName}>
+            ブログ
           </Link>
           <Link href="/achievements" onClick={closeMenu} className={styles.hamburgerNavName}>
             活動実績
           </Link>
           <Link href="/faq" onClick={closeMenu} className={styles.hamburgerNavName}>
             FAQ
-          </Link>
-          <Link href="/blog" onClick={closeMenu} className={styles.hamburgerNavName}>
-            ブログ
           </Link>
         </nav>
         <Link href={FORM_URL} target="_blank" rel="noopener noreferrer" className={styles.contact}>


### PR DESCRIPTION
## 関連issue

## やったこと
before
<img width="1507" height="60" alt="スクリーンショット 2025-09-14 135723" src="https://github.com/user-attachments/assets/bbf73e47-7f1d-474d-8e2e-90c11271c462" />

after
<img width="1501" height="56" alt="スクリーンショット 2025-09-14 135705" src="https://github.com/user-attachments/assets/0c8a286f-b8a4-4735-a484-5563eb888bf4" />
