### PR TITLE
feat: add "num of blocks" to preview

### DIFF
--- a/src/features/BlogPreview/presentations/index.module.scss
+++ b/src/features/BlogPreview/presentations/index.module.scss
@@ -60,6 +60,14 @@
     }
   }
 
+  .blockCounterWrapper {
+    margin-bottom: 24px;
+
+    @media (max-width: $mobile) {
+      margin-bottom: 16px;
+    }
+  }
+
   .article {
     display: flex;
     align-items: flex-start;

--- a/src/features/BlogPreview/presentations/index.tsx
+++ b/src/features/BlogPreview/presentations/index.tsx
@@ -5,6 +5,7 @@ import { BlogArticleBodies } from "@/features/BlogArticleBodies";
 import { BlogArticleToc } from "@/features/BlogArticleToc";
 import { Block } from "@/types/block";
 import { Props as PageInfo } from "@/ui/ArticleTitle";
+import { BlockCounter } from "@/ui/BlockCounter";
 import styles from "./index.module.scss";
 import BlogPreviewBodySkelton from "../presentations/Skelton";
 
@@ -75,10 +76,17 @@ export const BlogPreviewPresentation: React.FC<Props> = ({
         ) : !notionId || !blocks || !pageInfo ? (
           <></>
         ) : (
-          <div className={styles.article}>
-            <BlogArticleBodies id={notionPageId} blocks={blocks} pageInfo={pageInfo} />
-            <BlogArticleToc blocks={blocks} />
-          </div>
+          <>
+            {blocks && blocks.length > 0 && (
+              <div className={styles.blockCounterWrapper}>
+                <BlockCounter currentCount={blocks.length} maxCount={100} />
+              </div>
+            )}
+            <div className={styles.article}>
+              <BlogArticleBodies id={notionPageId} blocks={blocks} pageInfo={pageInfo} />
+              <BlogArticleToc blocks={blocks} />
+            </div>
+          </>
         )}
         {blocks && pageInfo && (
           <button className={styles.reloadButton} onClick={showPreview}>

--- a/src/ui/BlockCounter/index.module.scss
+++ b/src/ui/BlockCounter/index.module.scss
@@ -1,0 +1,28 @@
+@use '@/styles/variables' as *;
+
+.container {
+  display: inline-block;
+}
+
+.count {
+  font-size: $text-sm;
+  font-weight: 500;
+  color: #666;
+  padding: 4px 12px;
+  border-radius: $rounded;
+  background-color: $primary-background;
+
+  @media (max-width: $mobile) {
+    font-size: $text-xs;
+  }
+
+  &.warning {
+    color: #ff9800;
+    background-color: #fff3e0;
+  }
+
+  &.error {
+    color: #f44336;
+    background-color: #ffebee;
+  }
+}

--- a/src/ui/BlockCounter/index.tsx
+++ b/src/ui/BlockCounter/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import styles from "./index.module.scss";
+
+type Props = {
+  currentCount: number;
+  maxCount: number;
+};
+
+export const BlockCounter: React.FC<Props> = ({ currentCount, maxCount }) => {
+  const percentage = (currentCount / maxCount) * 100;
+  const isNearLimit = percentage >= 80;
+  const isOverLimit = currentCount > maxCount;
+
+  return (
+    <div className={styles.container}>
+      <span
+        className={`${styles.count} ${isNearLimit ? styles.warning : ""} ${isOverLimit ? styles.error : ""}`}
+      >
+        {currentCount}/{maxCount}ブロック使用中
+      </span>
+    </div>
+  );
+};


### PR DESCRIPTION
## 関連issue
#163 

## やったこと
- PreviewページでNotionに使われているブロック数を表示

<img width="1440" height="900" alt="スクリーンショット 2025-12-11 21 37 27" src="https://github.com/user-attachments/assets/614a78ff-f36b-403f-80dc-7af1f8ec849b" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/5380f7a5-64c2-4a92-98cf-afbaa4d26da0" />




