### PR TITLE
fix: ブログページにおいて画像が表示される速度とUIを改善

### DIFF
--- a/src/features/BlogArticleBodies/presentations/blocks/column/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/column/index.module.scss
@@ -1,0 +1,15 @@
+@use "@/styles/variables" as *;
+
+.column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (max-width: $mobile) {
+  .column {
+    width: 100%;
+  }
+}

--- a/src/features/BlogArticleBodies/presentations/blocks/column/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/column/index.tsx
@@ -1,5 +1,6 @@
 import { renderBlock } from "@/features/BlogArticleBodies/hooks/renderBlock";
 import { Column, Block } from "@/types/block";
+import styles from "./index.module.scss";
 
 type Props = {
   column?: Column;
@@ -9,5 +10,9 @@ type Props = {
 
 export const ColumnPresentation: React.FC<Props> = ({ column, childBlocks, pageId }) => {
   if (!column) return null;
-  return <div>{childBlocks && childBlocks.map((block: Block) => renderBlock(block, pageId))}</div>;
+  return (
+    <div className={styles.column}>
+      {childBlocks && childBlocks.map((block: Block) => renderBlock(block, pageId))}
+    </div>
+  );
 };

--- a/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.css
+++ b/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.css
@@ -1,8 +1,0 @@
-.row {
-    display: flex;
-  }
-  
-  .row > div {
-    flex: 1;
-  }
-  

--- a/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.scss
@@ -1,0 +1,17 @@
+@use "@/styles/variables" as *;
+
+.row {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  align-items: flex-start;
+}
+
+@media (max-width: $mobile) {
+  .row {
+    flex-direction: column;
+    gap: 2rem;
+  }
+}

--- a/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/columnList/index.module.scss
@@ -5,7 +5,6 @@
   flex-direction: row;
   width: 100%;
   gap: 1.5rem;
-  margin: 1rem 0;
   align-items: flex-start;
 }
 

--- a/src/features/BlogArticleBodies/presentations/blocks/columnList/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/columnList/index.tsx
@@ -1,6 +1,6 @@
 import { renderBlock } from "@/features/BlogArticleBodies/hooks/renderBlock";
 import { ColumnList, Block } from "@/types/block";
-import styles from "./index.module.css";
+import styles from "./index.module.scss";
 
 type Props = {
   columnList?: ColumnList;

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
@@ -5,18 +5,18 @@
   margin-right: auto;
   width: 100%;
   max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .imageWrapper {
-  display: flex;
-  justify-content: center;
+  position: relative;
+  width: 100%;
+  max-height: 60vh;
 }
 
 .image {
-  width: auto !important;
-  max-width: 100%;
-  max-height: 70vh;
-  height: auto !important;
   object-fit: contain;
 }
 

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
@@ -1,0 +1,19 @@
+.figure {
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 800px;
+}
+
+.imageWrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.image {
+  width: auto !important;
+  max-width: 100%;
+  max-height: 70vh;
+  height: auto !important;
+  object-fit: contain;
+}

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.module.scss
@@ -1,3 +1,5 @@
+@use "@/styles/variables" as *;
+
 .figure {
   margin-left: auto;
   margin-right: auto;
@@ -16,4 +18,11 @@
   max-height: 70vh;
   height: auto !important;
   object-fit: contain;
+}
+
+.caption {
+  margin-top: 0.75rem;
+  font-size: $text-sm;
+  color: #65717b;
+  text-align: center;
 }

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Image as ImageBlock } from "@/types/block";
+import styles from "./index.module.scss";
 
 type Props = {
   image?: ImageBlock;
@@ -15,15 +16,17 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
 
   const caption = image.caption ? image.caption[0]?.plain_text : "";
   return (
-    <figure className="mx-auto m-8 w-full  max-w-[800px]">
-      <Image
-        src={src}
-        alt={caption}
-        width={1200}
-        height={1200}
-        sizes="(max-width: 1023px) 100vw, 800px"
-        style={{ width: "100%", height: "auto" }}
-      />
+    <figure className={styles.figure}>
+      <div className={styles.imageWrapper}>
+        <Image
+          className={styles.image}
+          src={src}
+          alt={caption}
+          width={1200}
+          height={1200}
+          sizes="(max-width: 1023px) 100vw, 800px"
+        />
+      </div>
       {caption && <figcaption>{caption}</figcaption>}
     </figure>
   );

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -20,7 +20,10 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
   const caption = image.caption ? image.caption[0]?.plain_text : "";
   return (
     <figure className={styles.figure}>
-      <div className={styles.imageWrapper} style={{ aspectRatio: `${width} / ${height}` }}>
+      <div
+        className={styles.imageWrapper}
+        style={{ aspectRatio: width && height ? `${width} / ${height}` : "16 / 9" }}
+      >
         <Image
           className={styles.image}
           src={src}

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Image as ImageBlock } from "@/types/block";
 
 type Props = {
@@ -8,18 +9,21 @@ type Props = {
 
 export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
   if (!image) return null;
-  let src = "";
-  image.type === "external" && image.external && (src = image.external.url);
-  image.type === "file" && image.file && (src = image.file?.url);
+
+  const src = image.type === "external" ? image.external?.url : image.file?.url;
+  if (!src) return null;
 
   const caption = image.caption ? image.caption[0]?.plain_text : "";
   return (
-    <figure className="mx-auto">
-      {image.type === "external" ? (
-        <img src={src} alt={caption} width={500} height={500} />
-      ) : (
-        <img src={src} alt={caption} width={500} height={500} />
-      )}
+    <figure className="mx-auto m-8 w-full  max-w-[800px]">
+      <Image
+        src={src}
+        alt={caption}
+        width={1200}
+        height={1200}
+        sizes="(max-width: 1023px) 100vw, 800px"
+        style={{ width: "100%", height: "auto" }}
+      />
       {caption && <figcaption>{caption}</figcaption>}
     </figure>
   );

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -27,7 +27,7 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
           sizes="(max-width: 1023px) 100vw, 800px"
         />
       </div>
-      {caption && <figcaption>{caption}</figcaption>}
+      {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
     </figure>
   );
 };

--- a/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
+++ b/src/features/BlogArticleBodies/presentations/blocks/image/index.tsx
@@ -14,16 +14,18 @@ export const ImagePresentation: React.FC<Props> = ({ image, id, pageId }) => {
   const src = image.type === "external" ? image.external?.url : image.file?.url;
   if (!src) return null;
 
+  const width = image.width;
+  const height = image.height;
+
   const caption = image.caption ? image.caption[0]?.plain_text : "";
   return (
     <figure className={styles.figure}>
-      <div className={styles.imageWrapper}>
+      <div className={styles.imageWrapper} style={{ aspectRatio: `${width} / ${height}` }}>
         <Image
           className={styles.image}
           src={src}
           alt={caption}
-          width={1200}
-          height={1200}
+          fill
           sizes="(max-width: 1023px) 100vw, 800px"
         />
       </div>

--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -33,13 +33,17 @@ export const getStaticProps = async () => {
       if (achievement.properties.Image.files && achievement.properties.Image.files.length > 0) {
         if (achievement.properties.Image.files[0].file?.url) {
           if (!achievement.cover) {
-            res.image = await createImage(
-              achievement.id,
-              "cover",
-              achievement.properties.Image.files[0].file.url,
-            );
+            res.image = (
+              await createImage(
+                achievement.id,
+                "cover",
+                achievement.properties.Image.files[0].file.url,
+              )
+            ).url;
           } else if (achievement.cover.type === "file") {
-            res.image = await createImage(achievement.id, "cover", achievement.cover.file.url);
+            res.image = (
+              await createImage(achievement.id, "cover", achievement.cover.file.url)
+            ).url;
           } else if (achievement.cover.type === "external") {
             res.image = achievement.cover.external.url;
           }

--- a/src/pages/blog/[id]/index.tsx
+++ b/src/pages/blog/[id]/index.tsx
@@ -97,14 +97,16 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
       if (!image) return block;
 
       if (image.type === "file" && image.file) {
-        const url = await createImage(pageId, id, image.file.url);
+        const imageData = await createImage(pageId, id, image.file.url);
         filteredBlock = {
           ...block,
           image: {
             ...image,
+            width: imageData.width,
+            height: imageData.height,
             file: {
               ...image.file,
-              url,
+              url: imageData.url,
             },
           },
         };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,13 +53,11 @@ export const getStaticProps = async () => {
         if (product.properties.Image.files && product.properties.Image.files.length > 0) {
           if (product.properties.Image.files[0].file?.url) {
             if (!product.cover) {
-              res.image = await createImage(
-                product.id,
-                "cover",
-                product.properties.Image.files[0].file.url,
-              );
+              res.image = (
+                await createImage(product.id, "cover", product.properties.Image.files[0].file.url)
+              ).url;
             } else if (product.cover.type === "file") {
-              res.image = await createImage(product.id, "cover", product.cover.file.url);
+              res.image = (await createImage(product.id, "cover", product.cover.file.url)).url;
             } else if (product.cover.type === "external") {
               res.image = product.cover.external.url;
             }
@@ -120,7 +118,7 @@ export const getStaticProps = async () => {
           );
         } else if (article.cover.type === "file") {
           // カバー画像のtypeがfileの場合、有効期限があるのでbufferに変換する
-          res.image = await createImage(article.id, "cover", article.cover.file.url);
+          res.image = (await createImage(article.id, "cover", article.cover.file.url)).url;
         } else if (article.cover.type === "external") {
           res.image = article.cover.external.url;
         }

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -43,13 +43,11 @@ export const getStaticProps = async () => {
       if (product.properties.Image.files && product.properties.Image.files.length > 0) {
         if (product.properties.Image.files[0].file?.url) {
           if (!product.cover) {
-            res.image = await createImage(
-              product.id,
-              "cover",
-              product.properties.Image.files[0].file.url,
-            );
+            res.image = (
+              await createImage(product.id, "cover", product.properties.Image.files[0].file.url)
+            ).url;
           } else if (product.cover.type === "file") {
-            res.image = await createImage(product.id, "cover", product.cover.file.url);
+            res.image = (await createImage(product.id, "cover", product.cover.file.url)).url;
           } else if (product.cover.type === "external") {
             res.image = product.cover.external.url;
           }

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -28,11 +28,8 @@ const createImage = async function (id: string, name: string, url: string) {
   const binary = await src.arrayBuffer();
   const buffer = Buffer.from(binary);
 
-  // sharpでメタデータを取得
-  const metadata = await sharp(buffer).rotate().metadata();
-
   //Sharpによる画像処理
-  await sharp(buffer)
+  const output = await sharp(buffer)
     .rotate()
     .resize(1200, null, { withoutEnlargement: true, fit: "inside" })
     .webp({ quality: 80 })
@@ -40,8 +37,8 @@ const createImage = async function (id: string, name: string, url: string) {
 
   return {
     url: `/${id}/${name}.webp`,
-    width: metadata.width,
-    height: metadata.height,
+    width: output.width,
+    height: output.height,
   };
 };
 

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import sharp from "sharp";
 
 const createImage = async function (id: string, name: string, url: string) {
   // Notionの画像は期限付きのURLなので、そのまま表示すると期限切れで表示できなくなる
@@ -6,19 +7,30 @@ const createImage = async function (id: string, name: string, url: string) {
   // 参考: https://github.com/0si43/shetommy.com/pull/36/files
 
   const path = `public/${id}/`;
-  const cover = `${path}/${name}.png`;
+  //拡張子を .webpに変更
+  const cover = `${path}/${name}.webp`;
+
+  // 既にファイルが存在すれば再取得しない
+  if (fs.existsSync(cover)) {
+    return `/${id}/${name}.webp`;
+  }
 
   if (!fs.existsSync(path)) {
-    fs.mkdirSync(path);
+    fs.mkdirSync(path, { recursive: true });
   }
 
   const src = await fetch(url).then((r) => r.blob());
   const binary = await src.arrayBuffer();
   const buffer = Buffer.from(binary);
 
-  await fs.promises.writeFile(cover, buffer);
+  //Sharpによる画像処理
+  await sharp(buffer)
+    .rotate()
+    .resize(1200, null, { withoutEnlargement: true, fit: "inside" })
+    .webp({ quality: 80 })
+    .toFile(cover);
 
-  const result = `/${id}/${name}.png`;
+  const result = `/${id}/${name}.webp`;
   return result;
 };
 

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -12,7 +12,12 @@ const createImage = async function (id: string, name: string, url: string) {
 
   // 既にファイルが存在すれば再取得しない
   if (fs.existsSync(cover)) {
-    return `/${id}/${name}.webp`;
+    const metadata = await sharp(cover).rotate().metadata();
+    return {
+      url: `/${id}/${name}.webp`,
+      width: metadata.width,
+      height: metadata.height,
+    };
   }
 
   if (!fs.existsSync(path)) {
@@ -23,6 +28,9 @@ const createImage = async function (id: string, name: string, url: string) {
   const binary = await src.arrayBuffer();
   const buffer = Buffer.from(binary);
 
+  // sharpでメタデータを取得
+  const metadata = await sharp(buffer).rotate().metadata();
+
   //Sharpによる画像処理
   await sharp(buffer)
     .rotate()
@@ -30,8 +38,11 @@ const createImage = async function (id: string, name: string, url: string) {
     .webp({ quality: 80 })
     .toFile(cover);
 
-  const result = `/${id}/${name}.webp`;
-  return result;
+  return {
+    url: `/${id}/${name}.webp`,
+    width: metadata.width,
+    height: metadata.height,
+  };
 };
 
 export default createImage;

--- a/src/utils/useGetArticles.ts
+++ b/src/utils/useGetArticles.ts
@@ -57,7 +57,7 @@ export const getArticles: UseGetArticles = async (tagParam?: string, writerParam
           res.image = `/${article.id}/ogp.png`;
         } else if (article.cover.type === "file") {
           // カバー画像のtypeがfileの場合、有効期限があるのでbufferに変換する
-          res.image = await createImage(article.id, "cover", article.cover.file.url);
+          res.image = (await createImage(article.id, "cover", article.cover.file.url)).url;
         } else if (article.cover.type === "external") {
           res.image = article.cover.external.url;
         }


### PR DESCRIPTION
## 関連issue

#170 

## やったこと

### 画像を保存する方法を改善する
- .webp形式で保存
- 画像サイズを1200pxにリサイズ(画像が1200より小さかった場合は無理に大きくしない)(主に1200pxより高解像度の画像を小さく保存するためのもの)

### 画像を表示する方法を改善する
- `<img>`タグをNext.js の `<Image />` コンポーネントに置き換えることで，Lazy Loading（遅延読み込み)を自動適用

### (主に)ブログページにおいて，スマホで撮った縦向きの画像が横向きになることを修正
- `rotate()`を指定

### Notionのカラム構造に対応するコンポーネントのスタイルを修正
- `ColumnListPresentation`
- `ColumnPresentation`

### コードのリファクタリング

## 動画
**before**

https://github.com/user-attachments/assets/99a8fe7c-84e5-41b9-95f2-1f37f0731222

**after**

https://github.com/user-attachments/assets/366bfd7e-eb31-47fd-ba6c-8e8a39ecb439

## スクショ

**before**
<img width="789" height="730" alt="スクリーンショット 2026-03-11 192407" src="https://github.com/user-attachments/assets/ce70c88a-b0d1-4620-83d8-4ba1b5fb465c" />
<img width="381" height="814" alt="スクリーンショット 2026-03-11 192445" src="https://github.com/user-attachments/assets/4ceab661-b57c-4e16-b5b9-b05fe0e7c98d" />

**after**
<img width="825" height="807" alt="スクリーンショット 2026-03-11 190924" src="https://github.com/user-attachments/assets/f276a916-223f-4b18-ad70-4e5ce5b34f45" />
<img width="375" height="818" alt="スクリーンショット 2026-03-11 190952" src="https://github.com/user-attachments/assets/6d5a7c5e-c26c-458c-b35c-86ce063ef47a" />

## Notionリンク
[https://www.notion.so/31ff301ff17580088b33f5134f270882?source=copy_link](url)
