### PR TITLE
ブログの筆者画像の読み込みスピードが遅いのを改善

### DIFF
--- a/src/pages/blog/[id]/index.tsx
+++ b/src/pages/blog/[id]/index.tsx
@@ -2,6 +2,7 @@ import { BlogArticleScreen } from "@/screens/BlogArticle";
 import { Block, Column } from "@/types/block";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
 import { Props as PageInfo } from "@/ui/ArticleTitle";
+import { cacheRemoteAvatar } from "@/utils/cacheRemoteAvatar";
 import cacheRemoteImage from "@/utils/cacheRemoteImage";
 import createOGPImage from "@/utils/createOGPImage";
 import { Meta } from "@/utils/meta";
@@ -53,10 +54,13 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
   const pageId = params.id as string;
   const blocks = (await getBlocks(pageId)) as Block[];
   const page = (await getPage(pageId)) as any;
+  const writerId = page.properties.Writer.created_by.id;
+  const rawAvatarUrl = page.properties.Writer.created_by.avatar_url;
+  const optimizedAvatarUrl = rawAvatarUrl ? await cacheRemoteAvatar(writerId, rawAvatarUrl) : null;
   const pageInfo = {
     title: page.properties.Name.title[0].plain_text,
     writerName: page.properties.Writer.created_by.name || null,
-    writerImage: page.properties.Writer.created_by.avatar_url || null,
+    writerImage: optimizedAvatarUrl,
     tags: page.properties.tag.multi_select,
     date: page.properties.Publish_Date.date
       ? page.properties.Publish_Date.date.start

--- a/src/ui/Writer/index.tsx
+++ b/src/ui/Writer/index.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 import styles from "./index.module.scss";
@@ -12,13 +13,27 @@ export const Writer: React.FC<Props> = ({ writerName, writerImage, isLink = fals
   return isLink ? (
     <Link href={`/blog/writer/${writerName}`}>
       <div className={styles.link}>
-        <img className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
+        <Image
+          className={styles.image}
+          src={writerImage}
+          alt={writerName}
+          width={24}
+          height={24}
+          unoptimized
+        />
         <span className={styles.name}>{writerName}</span>
       </div>
     </Link>
   ) : (
     <div className={styles.writer}>
-      <img className={styles.image} src={writerImage} alt={writerName} width={24} height={24} />
+      <Image
+        className={styles.image}
+        src={writerImage}
+        alt={writerName}
+        width={24}
+        height={24}
+        unoptimized
+      />
       <span className={styles.name}>{writerName}</span>
     </div>
   );

--- a/src/utils/cacheRemoteAvatar.ts
+++ b/src/utils/cacheRemoteAvatar.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import sharp from "sharp";
+
+export const cacheRemoteAvatar = async (id: string, url: string) => {
+  if (!url) return null;
+
+  const dirPath = `public/avatars/${id}`;
+  const filePath = `${dirPath}/icon.webp`;
+  const publicPath = `/avatars/${id}/icon.webp`;
+
+  if (fs.existsSync(filePath)) return publicPath;
+
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("Fetch failed");
+  const buffer = Buffer.from(await response.arrayBuffer());
+
+  await sharp(buffer)
+    .rotate()
+    .resize(120, 120, { fit: "cover", kernel: sharp.kernel.lanczos3 })
+    .sharpen()
+    .webp({ quality: 100, lossless: true })
+    .toFile(filePath);
+
+  return publicPath;
+};

--- a/src/utils/cacheRemoteAvatar.ts
+++ b/src/utils/cacheRemoteAvatar.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import fs from "fs";
 import sharp from "sharp";
 
@@ -5,13 +6,22 @@ export const cacheRemoteAvatar = async (id: string, url: string) => {
   if (!url) return null;
 
   const dirPath = `public/avatars/${id}`;
-  const filePath = `${dirPath}/icon.webp`;
-  const publicPath = `/avatars/${id}/icon.webp`;
+  const baseUrl = url.split("?")[0];
+  const hashedUrl = createHash("sha256").update(baseUrl).digest("hex").slice(0, 16);
+  const fileName = `${hashedUrl}.webp`;
+  const filePath = `${dirPath}/${fileName}`;
+  const publicPath = `/avatars/${id}/${fileName}`;
 
   if (fs.existsSync(filePath)) return publicPath;
 
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
+  }
+
+  // 古い画像は削除する
+  const oldFiles = fs.readdirSync(dirPath).filter((name) => name !== fileName);
+  for (const oldFile of oldFiles) {
+    fs.rmSync(`${dirPath}/${oldFile}`, { force: true });
   }
 
   const response = await fetch(url);


### PR DESCRIPTION
## 関連issue
#179 

## やったこと
cacheRemoteAvatorフックを追加した
- 画像をローカルに保存
- webp形式で保存
- リサイズで小さく
- アイコン画像が更新されたときに備えた機能も追加