### PR TITLE
Notionから取得する画像のサイズを用いて実績部分の画像表示を修正

### DIFF
--- a/src/features/AchievementList/presentations/index.stories.tsx
+++ b/src/features/AchievementList/presentations/index.stories.tsx
@@ -9,12 +9,12 @@ type Achievement = {
   id: string;
   date: string;
   text: string;
-  image: string;
-  article_href: string;
-  web_href: string;
-  app_href: string;
-  google_href: string;
-  git_href: string;
+  image: { url: string; width: number | undefined; height: number | undefined };
+  article_href?: string;
+  web_href?: string;
+  app_href?: string;
+  google_href?: string;
+  git_href?: string;
 };
 
 const sampleAchievements: Record<string, Achievement[]> = {
@@ -23,10 +23,14 @@ const sampleAchievements: Record<string, Achievement[]> = {
       id: "2024",
       date: "2024-06-02",
       text: "test1",
-      image: "https://placehold.jp/200x200.png",
+      image: {
+        url: "https://placehold.jp/200x200.png",
+        width: 200,
+        height: 200,
+      },
       article_href: "https://ejje.weblio.jp/content/test",
       web_href: "https://www.youtube.com/",
-      app_href: " https://www.youtube.com/",
+      app_href: "https://www.youtube.com/",
       google_href: "https://www.youtube.com/",
       git_href: "https://github.com/jack-app/jackweb3/issues/45",
     },
@@ -34,7 +38,11 @@ const sampleAchievements: Record<string, Achievement[]> = {
       id: "2024",
       date: "2024-05-20",
       text: "testtesttesttesttesttesttesttest4",
-      image: "",
+      image: {
+        url: "https://placehold.jp/200x200.png",
+        width: 200,
+        height: 200,
+      },
       article_href: "",
       web_href: "",
       app_href: "",
@@ -47,10 +55,14 @@ const sampleAchievements: Record<string, Achievement[]> = {
       id: "2023",
       date: "2023-05-15",
       text: "test2",
-      image: "https://placehold.jp/200x200.png",
+      image: {
+        url: "https://placehold.jp/200x200.png",
+        width: 200,
+        height: 200,
+      },
       article_href: "https://ejje.weblio.jp/content/test",
       web_href: "",
-      app_href: " ",
+      app_href: "",
       google_href: "",
       git_href: "",
     },
@@ -60,10 +72,14 @@ const sampleAchievements: Record<string, Achievement[]> = {
       id: "2022",
       date: "2022-05-14",
       text: "test3",
-      image: "",
+      image: {
+        url: "https://placehold.jp/200x200.png",
+        width: 200,
+        height: 200,
+      },
       article_href: "",
       web_href: "",
-      app_href: " ",
+      app_href: "",
       google_href: "https://www.youtube.com/",
       git_href: "https://github.com/jack-app/jackweb3/issues/45",
     },
@@ -78,8 +94,8 @@ const meta: Meta<T> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    sortedYear: { control: sampleYears },
-    groupedAchievement: { control: sampleAchievements },
+    sortedYear: { control: "object" },
+    groupedAchievement: { control: "object" },
   },
 };
 

--- a/src/features/AchievementList/presentations/index.stories.tsx
+++ b/src/features/AchievementList/presentations/index.stories.tsx
@@ -9,7 +9,7 @@ type Achievement = {
   id: string;
   date: string;
   text: string;
-  image: { url: string; width: number | undefined; height: number | undefined };
+  image: { url: string; width?: number; height?: number };
   article_href?: string;
   web_href?: string;
   app_href?: string;

--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -21,7 +21,7 @@ export const getStaticProps = async () => {
         id: achievement.id,
         image: { url: "", width: undefined, height: undefined },
         date: achievement.properties.Date.date.start,
-        text: achievement.properties.Name.title[0]?.plain_text || null,
+        text: achievement.properties.Name.title.map((t: any) => t.plain_text).join("") || null,
         article_href: achievement.properties.Article.url || null,
         web_href: achievement.properties.WebLink.url || null,
         app_href: achievement.properties.AppStore.url || null,

--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -51,7 +51,7 @@ export const getStaticProps = async () => {
             res.image.width = imageData.width;
             res.image.height = imageData.height;
           } else if (achievement.cover.type === "external") {
-            res.image = achievement.cover.external.url;
+            res.image.url = achievement.cover.external.url;
           }
         }
       }

--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -19,7 +19,7 @@ export const getStaticProps = async () => {
     achievementDb.map(async (achievement: any) => {
       const res = {
         id: achievement.id,
-        image: "",
+        image: { url: "", width: undefined, height: undefined },
         date: achievement.properties.Date.date.start,
         text: achievement.properties.Name.title[0]?.plain_text || null,
         article_href: achievement.properties.Article.url || null,
@@ -33,17 +33,23 @@ export const getStaticProps = async () => {
       if (achievement.properties.Image.files && achievement.properties.Image.files.length > 0) {
         if (achievement.properties.Image.files[0].file?.url) {
           if (!achievement.cover) {
-            res.image = (
-              await cacheRemoteImage(
-                achievement.id,
-                "cover",
-                achievement.properties.Image.files[0].file.url,
-              )
-            ).url;
+            const imageData = await cacheRemoteImage(
+              achievement.id,
+              "cover",
+              achievement.properties.Image.files[0].file.url,
+            );
+            res.image.url = imageData.url;
+            res.image.width = imageData.width;
+            res.image.height = imageData.height;
           } else if (achievement.cover.type === "file") {
-            res.image = (
-              await cacheRemoteImage(achievement.id, "cover", achievement.cover.file.url)
-            ).url;
+            const imageData = await cacheRemoteImage(
+              achievement.id,
+              "cover",
+              achievement.cover.file.url,
+            );
+            res.image.url = imageData.url;
+            res.image.width = imageData.width;
+            res.image.height = imageData.height;
           } else if (achievement.cover.type === "external") {
             res.image = achievement.cover.external.url;
           }

--- a/src/ui/AchievementItem/index.module.scss
+++ b/src/ui/AchievementItem/index.module.scss
@@ -51,10 +51,10 @@
   @media (max-width: $pc) {
     display: none;
   }
+}
 
-  .image {
-    object-fit: contain;
-  }
+.image {
+  object-fit: contain;
 }
 
 .tag {

--- a/src/ui/AchievementItem/index.module.scss
+++ b/src/ui/AchievementItem/index.module.scss
@@ -1,72 +1,73 @@
-@use '@/styles/variables' as *;
+@use "@/styles/variables" as *;
 
-.wrapper{
-    width: 100%;
-    display: flex;
-    background-color: #FFF4E3;
-    padding: 32px;
-    border-radius: $rounded-lg;
-    @media(max-width: $mobile){
-        padding: 16px;
-    }
+.wrapper {
+  width: 100%;
+  display: flex;
+  background-color: #fff4e3;
+  padding: 32px;
+  border-radius: $rounded-lg;
+  gap: 2rem;
+  @media (max-width: $mobile) {
+    padding: 16px;
+  }
 }
 
-.context{
-    justify-content: space-between;
-    flex-flow: column ;
-    display: flex;
+.context {
+  justify-content: space-between;
+  flex-flow: column;
+  display: flex;
 }
-.date{
-    background-color: $white;
-    border-radius: $rounded-full;
-    text-align: center;
-    padding: 8px 16px;
-    width: 128px;
-    height: 40px;
-    @media (max-width: $mobile){
-        font-size: $text-sm;
-        height: 36px;
-        width: fit-content;
-    }
-}
-
-.text{
-    font-size: $text-3xl;
-    font-weight: 600;
-    @media(max-width: $pc){
-        font-size: $text-xl;
-        margin-top: 10px;
-    }
-    @media (max-width: $mobile){
-        font-size: $text-base;
-    }
+.date {
+  background-color: $white;
+  border-radius: $rounded-full;
+  text-align: center;
+  padding: 8px 16px;
+  width: 128px;
+  height: 40px;
+  @media (max-width: $mobile) {
+    font-size: $text-sm;
+    height: 36px;
+    width: fit-content;
+  }
 }
 
-.image{
-    width: 200px;
-    height: 200px;
-    object-fit: fill;
-    text-align: right;
-    justify-content: flex-end;
-    object-fit: cover;
-    margin-left: auto;
-    padding: 0;
-    @media (max-width: $pc){
-        display: none;
-    }
+.text {
+  font-size: $text-3xl;
+  font-weight: 600;
+  @media (max-width: $pc) {
+    font-size: $text-xl;
+    margin-top: 10px;
+  }
+  @media (max-width: $mobile) {
+    font-size: $text-base;
+  }
 }
 
-.tag{
-    width:100%;
-    display:flex;
-    flex-wrap: wrap;
-    padding: 0;
-    margin: 0;
-    @media (max-width: $pc){
-        margin-top: 10px;
-    }
+.imageWrapper {
+  position: relative;
+  width: 200px;
+  min-height: 200px;
+  margin-left: auto;
+  @media (max-width: $pc) {
+    display: none;
+  }
+
+  .image {
+    object-fit: contain;
+  }
 }
 
-.tag > div{
-    gap: 8px;
+.tag {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0;
+  margin: 0;
+  @media (max-width: $pc) {
+    margin-top: 10px;
+  }
+}
+
+.tag > div {
+  gap: 8px;
 }

--- a/src/ui/AchievementItem/index.module.scss
+++ b/src/ui/AchievementItem/index.module.scss
@@ -3,7 +3,7 @@
 .wrapper {
   width: 100%;
   display: flex;
-  background-color: #fff4e3;
+  background-color: $primary-background;
   padding: 32px;
   border-radius: $rounded-lg;
   gap: 2rem;
@@ -63,11 +63,8 @@
   flex-wrap: wrap;
   padding: 0;
   margin: 0;
+  gap: 8px;
   @media (max-width: $pc) {
     margin-top: 10px;
   }
-}
-
-.tag > div {
-  gap: 8px;
 }

--- a/src/ui/AchievementItem/index.stories.tsx
+++ b/src/ui/AchievementItem/index.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<T> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    image: { control: "text" },
+    image: { control: "object" },
     date: { control: "text" },
     text: { control: "text" },
     article_href: { control: "text" },
@@ -27,6 +27,7 @@ type Story = StoryObj<T>;
 
 export const Default: Story = {
   args: {
+    id: "achievement-1",
     image: {
       url: "https://placehold.jp/200x200.png",
       width: 200,

--- a/src/ui/AchievementItem/index.stories.tsx
+++ b/src/ui/AchievementItem/index.stories.tsx
@@ -27,7 +27,11 @@ type Story = StoryObj<T>;
 
 export const Default: Story = {
   args: {
-    image: "https://placehold.jp/200x200.png",
+    image: {
+      url: "https://placehold.jp/200x200.png",
+      width: 200,
+      height: 200,
+    },
     date: "2021-01-01",
     text: "Title",
     article_href: "https://www.google.com/",

--- a/src/ui/AchievementItem/index.tsx
+++ b/src/ui/AchievementItem/index.tsx
@@ -85,7 +85,7 @@ export const AchievementItem: React.FC<Props> = ({
       <div
         className={styles.imageWrapper}
         style={{
-          aspectRatio: image.width && image.height ? `${image.width} / ${image.height}` : "16 / 9",
+          aspectRatio: image.width && image.height ? `${image.width} / ${image.height}` : "1 / 1",
         }}
       >
         <Image

--- a/src/ui/AchievementItem/index.tsx
+++ b/src/ui/AchievementItem/index.tsx
@@ -11,7 +11,7 @@ export type Props = {
   id: string;
   date: string;
   text: string;
-  image: string;
+  image: { url: string; width: number | undefined; height: number | undefined };
   article_href?: string;
   web_href?: string;
   app_href?: string;
@@ -84,7 +84,20 @@ export const AchievementItem: React.FC<Props> = ({
           </div>
         </div>
       </div>
-      <Image className={styles.image} src={image} alt="" width={200} height={200} />
+      <div
+        className={styles.imageWrapper}
+        style={{
+          aspectRatio: image.width && image.height ? `${image.width} / ${image.height}` : "16 / 9",
+        }}
+      >
+        <Image
+          className={styles.image}
+          src={image.url}
+          alt=""
+          fill
+          sizes="(max-width: 768px) 100vw, 300px"
+        />
+      </div>
     </div>
   );
 };

--- a/src/ui/AchievementItem/index.tsx
+++ b/src/ui/AchievementItem/index.tsx
@@ -11,7 +11,7 @@ export type Props = {
   id: string;
   date: string;
   text: string;
-  image: { url: string; width: number | undefined; height: number | undefined };
+  image: { url: string; width?: number; height?: number };
   article_href?: string;
   web_href?: string;
   app_href?: string;

--- a/src/ui/AchievementItem/index.tsx
+++ b/src/ui/AchievementItem/index.tsx
@@ -36,52 +36,50 @@ export const AchievementItem: React.FC<Props> = ({
         <div className={styles.date}>{date}</div>
         <div className={styles.text}>{text}</div>
         <div className={styles.tag}>
-          <div className={styles.tag}>
-            {article_href && (
-              <div>
-                <IconLink
-                  href={article_href}
-                  text="See Article"
-                  icon={FaExternalLinkAlt}
-                  size="s"
-                  openInNewTab
-                />
-              </div>
-            )}
-            {web_href && (
-              <div>
-                <IconLink
-                  href={web_href}
-                  text="webサイト"
-                  icon={FaExternalLinkAlt}
-                  size="s"
-                  openInNewTab
-                />
-              </div>
-            )}
-            {app_href && (
-              <div>
-                <IconLink href={app_href} text="App Store" icon={FaApple} size="s" openInNewTab />
-              </div>
-            )}
-            {google_href && (
-              <div>
-                <IconLink
-                  href={google_href}
-                  text="Google Play"
-                  icon={FaGooglePlay}
-                  size="s"
-                  openInNewTab
-                />
-              </div>
-            )}
+          {article_href && (
+            <div>
+              <IconLink
+                href={article_href}
+                text="See Article"
+                icon={FaExternalLinkAlt}
+                size="s"
+                openInNewTab
+              />
+            </div>
+          )}
+          {web_href && (
+            <div>
+              <IconLink
+                href={web_href}
+                text="webサイト"
+                icon={FaExternalLinkAlt}
+                size="s"
+                openInNewTab
+              />
+            </div>
+          )}
+          {app_href && (
+            <div>
+              <IconLink href={app_href} text="App Store" icon={FaApple} size="s" openInNewTab />
+            </div>
+          )}
+          {google_href && (
+            <div>
+              <IconLink
+                href={google_href}
+                text="Google Play"
+                icon={FaGooglePlay}
+                size="s"
+                openInNewTab
+              />
+            </div>
+          )}
 
-            {git_href && (
-              <div>
-                <IconLink href={git_href} text="GitHub" icon={FaGithub} size="s" openInNewTab />
-              </div>
-            )}
-          </div>
+          {git_href && (
+            <div>
+              <IconLink href={git_href} text="GitHub" icon={FaGithub} size="s" openInNewTab />
+            </div>
+          )}
         </div>
       </div>
       <div

--- a/src/ui/AchievementItem/index.tsx
+++ b/src/ui/AchievementItem/index.tsx
@@ -93,7 +93,7 @@ export const AchievementItem: React.FC<Props> = ({
         <Image
           className={styles.image}
           src={image.url}
-          alt=""
+          alt={text}
           fill
           sizes="(max-width: 768px) 100vw, 300px"
         />


### PR DESCRIPTION
## 関連issue
#181 

## やったこと
- すてきなロゴがみきれないように，実績ページの画像表示を固定サイズから実サイズに準拠した比率で表示するように修正
- ついでに，実績名が分割されても正しく表示されるように修正
- リファクタリング


## 画像

before
<img width="838" height="819" alt="スクリーンショット 2026-03-18 210741" src="https://github.com/user-attachments/assets/e7dbba29-0537-4ffc-b965-fa596a21ea2b" />


after
<img width="733" height="815" alt="image" src="https://github.com/user-attachments/assets/85d81b2c-6c94-444e-80e2-12b5a7e83e7d" />


