### PR TITLE
feat: ブラウザの戻る/進むでスクロール位置を復元

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    scrollRestoration: true,
+  },
   images: {
     domains: [
       "www.notion.so",


### PR DESCRIPTION
## 関連issue

#169

## やったこと

`next.config.mjs` に `experimental.scrollRestoration: true` を追加し、Next.js Pages Router 公式のスクロール復元機能を有効化しました。

### 挙動

- **戻る / 進むナビゲーション**: 前回のスクロール位置を自動で復元
- **新しいページ遷移 (`<Link>` クリック等)**: 従来どおりページ先頭にスクロール

### 動作確認手順

- [ ] 任意のページで下までスクロール → 別ページへ遷移 → ブラウザの戻るボタンで元のスクロール位置に戻ることを確認
- [ ] 新しいページへの遷移ではページ先頭にスクロールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)