### PR TITLE
perf: fallback: 'blocking' とISRでNotion APIの呼び出し回数を削減

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,3 +2,9 @@ export const FORM_URL =
   "https://docs.google.com/forms/d/e/1FAIpQLSc1-E-aEEFeRlxggQLTea6SY96W-1fNVUN5MxVYKWfmId1yUg/viewform";
 export const JOIN_URL =
   "https://docs.google.com/forms/d/e/1FAIpQLSdEsHCLaclQtPJf7it7b-N6OJIV9nXOwgEJA6Pl_hp6nYOeiA/viewform?usp=header";
+
+// ISR(Incremental Static Regeneration)の再生成間隔(秒)。
+// ビルド時に全ページを生成するのではなく、リクエスト時に生成してこの間隔でキャッシュを更新することで、
+// ビルドごとのNotion APIの呼び出し回数を大幅に削減する。
+// 1時間 = Notionの画像URLの有効期限ともおおよそ揃えている。
+export const ISR_REVALIDATE_SECONDS = 3600;

--- a/src/pages/achievements/index.tsx
+++ b/src/pages/achievements/index.tsx
@@ -1,3 +1,4 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { AchievementsScreen } from "@/screens/Achievements";
 import { Props as AchievementItemProps } from "@/ui/AchievementItem";
 import cacheRemoteImage from "@/utils/cacheRemoteImage";
@@ -62,5 +63,6 @@ export const getStaticProps = async () => {
     props: {
       achievements,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 };

--- a/src/pages/blog/[id]/index.tsx
+++ b/src/pages/blog/[id]/index.tsx
@@ -1,3 +1,4 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { BlogArticleScreen } from "@/screens/BlogArticle";
 import { Block, Column } from "@/types/block";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
@@ -5,7 +6,7 @@ import { Props as PageInfo } from "@/ui/ArticleTitle";
 import cacheRemoteImage from "@/utils/cacheRemoteImage";
 import createOGPImage from "@/utils/createOGPImage";
 import { Meta } from "@/utils/meta";
-import { getBlocks, getDatabase, getPage } from "@/utils/notion";
+import { getBlocks, getPage } from "@/utils/notion";
 import { getArticles } from "@/utils/useGetArticles";
 
 export default function Article({
@@ -42,17 +43,24 @@ export default function Article({
 }
 
 export const getStaticPaths = async () => {
-  const articles = await getArticles();
-
-  const paths = articles.map((article) => ({
-    params: { id: article.id },
-  }));
-
-  return { paths, fallback: false };
+  // ビルド時に全記事を事前生成すると記事数に比例してNotion APIを大量に呼び出してしまう。
+  // パスは事前生成せず、リクエスト時にオンデマンド生成し、ISRでキャッシュする。
+  return { paths: [], fallback: "blocking" };
 };
 
 export const getStaticProps = async ({ params }: { params: { id: string } }) => {
   const pageId = params.id as string;
+
+  // 公開記事の一覧。記事の存在確認とおすすめ記事の両方に使い回し、Notionへの問い合わせを1回に抑える。
+  const publicArticles = await getArticles();
+
+  // fallback: 'blocking' では任意のIDでアクセスされ得るため、
+  // 公開記事に含まれないID(非公開・存在しない・公開日前)は404にする。
+  const isPublicArticle = publicArticles.some((article) => article.id === pageId);
+  if (!isPublicArticle) {
+    return { notFound: true, revalidate: ISR_REVALIDATE_SECONDS };
+  }
+
   const blocks = (await getBlocks(pageId)) as Block[];
   const page = (await getPage(pageId)) as any;
   const createdBy = page.properties.Created_By?.formula?.string;
@@ -128,9 +136,7 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
     .join("");
   const description = fullText.length <= 100 ? fullText : fullText.slice(0, 100) + "...";
 
-  const getSuggestArticles = async () => {
-    const publicArticles = await getArticles();
-
+  const getSuggestArticles = () => {
     const shuffleArray = (array: any[]) => {
       for (let i = array.length - 1; i >= 0; i--) {
         const tmp = Math.floor(Math.random() * (i + 1));
@@ -140,12 +146,14 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
     };
 
     const suggestLength = 3;
-    const results = shuffleArray(publicArticles).slice(0, suggestLength);
+    // 表示中の記事を除いた公開記事からランダムに選ぶ(publicArticlesを再利用)
+    const candidates = publicArticles.filter((article) => article.id !== pageId);
+    const results = shuffleArray(candidates).slice(0, suggestLength);
 
     return results as ArticleItemProps[];
   };
 
-  const suggestArticles = await getSuggestArticles();
+  const suggestArticles = getSuggestArticles();
 
   const title = page.properties.Name.title[0].plain_text;
   const writerName = customName || createdBy || null;
@@ -160,5 +168,6 @@ export const getStaticProps = async ({ params }: { params: { id: string } }) => 
       description: description,
       lastEditedTime: page.last_edited_time,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 };

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,3 +1,4 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { BlogScreen } from "@/screens/Blog";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
 import { Meta } from "@/utils/meta";
@@ -19,5 +20,6 @@ export async function getStaticProps() {
     props: {
       articles,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 }

--- a/src/pages/blog/tag/[tag]/index.tsx
+++ b/src/pages/blog/tag/[tag]/index.tsx
@@ -1,7 +1,7 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { BlogScreen } from "@/screens/Blog";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
 import { Meta } from "@/utils/meta";
-import { getDatabase } from "@/utils/notion";
 import { getArticles } from "@/utils/useGetArticles";
 
 export default function TagPage({ tag, articles }: { tag: string; articles: ArticleItemProps[] }) {
@@ -15,31 +15,25 @@ export default function TagPage({ tag, articles }: { tag: string; articles: Arti
 }
 
 export async function getStaticPaths() {
-  const databaseId = process.env.NOTION_BLOG_DATABASE_ID;
-  const articleDb = await getDatabase(databaseId);
-
-  const tags = new Set<string>();
-  articleDb.forEach((article: any) => {
-    article.properties.tag.multi_select.forEach((tag: any) => {
-      tags.add(tag.name);
-    });
-  });
-
-  const paths = Array.from(tags).map((tag) => ({
-    params: { tag: tag },
-  }));
-
-  return { paths, fallback: false };
+  // タグの一覧取得のためだけにビルド時へNotionへ問い合わせるのを避け、
+  // リクエスト時にオンデマンド生成してISRでキャッシュする。
+  return { paths: [], fallback: "blocking" };
 }
 
 export async function getStaticProps({ params }: { params: { tag: string } }) {
   const tag = params.tag;
   const articles = await getArticles(tag);
 
+  // 公開記事が存在しないタグ(存在しないタグへの直接アクセスなど)は404にする。
+  if (articles.length === 0) {
+    return { notFound: true, revalidate: ISR_REVALIDATE_SECONDS };
+  }
+
   return {
     props: {
       tag,
       articles,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 }

--- a/src/pages/blog/writer/[writer]/index.tsx
+++ b/src/pages/blog/writer/[writer]/index.tsx
@@ -1,7 +1,7 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { BlogScreen } from "@/screens/Blog";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
 import { Meta } from "@/utils/meta";
-import { getDatabase } from "@/utils/notion";
 import { getArticles } from "@/utils/useGetArticles";
 
 export default function WriterPage({
@@ -22,33 +22,25 @@ export default function WriterPage({
 }
 
 export async function getStaticPaths() {
-  const databaseId = process.env.NOTION_BLOG_DATABASE_ID;
-  const articleDb = await getDatabase(databaseId);
-
-  const writers = new Set<string>();
-  articleDb.forEach((article: any) => {
-    const customName = article.properties.Custom_Name?.rich_text?.[0]?.plain_text;
-    const createdBy = article.properties.Created_By?.formula?.string;
-    const writerName = customName || createdBy;
-    if (writerName) {
-      writers.add(writerName);
-    }
-  });
-  const paths = Array.from(writers).map((writer) => ({
-    params: { writer: writer },
-  }));
-
-  return { paths, fallback: false };
+  // ライター一覧の取得のためだけにビルド時にNotionへ問い合わせるのを避け、
+  // リクエスト時にオンデマンド生成してISRでキャッシュする。
+  return { paths: [], fallback: "blocking" };
 }
 
 export async function getStaticProps({ params }: { params: { writer: string } }) {
   const writer = params.writer;
   const articles = await getArticles(undefined, params.writer);
 
+  // 公開記事が存在しないライター(存在しないライターへの直接アクセスなど)は404にする。
+  if (articles.length === 0) {
+    return { notFound: true, revalidate: ISR_REVALIDATE_SECONDS };
+  }
+
   return {
     props: {
       writer,
       articles,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { TopScreen } from "@/screens/Top";
 import { Props as ArticleItemProps } from "@/ui/ArticleItem";
 import { ProductionDetailProps as ProductionProps } from "@/ui/Production";
@@ -147,5 +148,6 @@ export const getStaticProps = async () => {
       product: filteredProduct,
       articles: filteredArticles,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 };

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -1,3 +1,4 @@
+import { ISR_REVALIDATE_SECONDS } from "@/constants";
 import { ProductsScreen } from "@/screens/Products";
 import { ProductionDetailProps as ProductionProps } from "@/ui/Production";
 import cacheRemoteImage from "@/utils/cacheRemoteImage";
@@ -73,5 +74,6 @@ export const getStaticProps = async () => {
     props: {
       products,
     },
+    revalidate: ISR_REVALIDATE_SECONDS,
   };
 };

--- a/src/utils/cacheRemoteImage.ts
+++ b/src/utils/cacheRemoteImage.ts
@@ -10,36 +10,52 @@ const cacheRemoteImage = async function (id: string, name: string, url: string) 
   //拡張子を .webpに変更
   const cover = `${path}/${name}.webp`;
 
-  // 既にファイルが存在すれば再取得しない
-  if (fs.existsSync(cover)) {
-    const metadata = await sharp(cover).rotate().metadata();
+  try {
+    // 既にファイルが存在すれば再取得しない
+    if (fs.existsSync(cover)) {
+      const metadata = await sharp(cover).rotate().metadata();
+      return {
+        url: `/${id}/${name}.webp`,
+        width: metadata.width,
+        height: metadata.height,
+      };
+    }
+
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path, { recursive: true });
+    }
+
+    const src = await fetch(url).then((r) => r.blob());
+    const binary = await src.arrayBuffer();
+    const buffer = Buffer.from(binary);
+
+    //Sharpによる画像処理
+    const output = await sharp(buffer)
+      .rotate()
+      .resize(1200, null, { withoutEnlargement: true, fit: "inside" })
+      .webp({ quality: 80 })
+      .toFile(cover);
+
     return {
       url: `/${id}/${name}.webp`,
-      width: metadata.width,
-      height: metadata.height,
+      width: output.width,
+      height: output.height,
+    };
+  } catch (error) {
+    // fallback: 'blocking' によりリクエスト時(サーバーレス環境)で実行された場合、
+    // public/ は読み取り専用のため書き込みに失敗する。
+    // その場合はキャッシュを諦め、Notionの元URLをそのまま返してページ生成を継続する。
+    // (revalidate間隔をNotionのURL有効期限とおおよそ揃えているため、表示は維持される)
+    console.warn(
+      `cacheRemoteImage: 画像をキャッシュできなかったため元URLを使用します (${id}/${name})`,
+      error,
+    );
+    return {
+      url,
+      width: undefined,
+      height: undefined,
     };
   }
-
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path, { recursive: true });
-  }
-
-  const src = await fetch(url).then((r) => r.blob());
-  const binary = await src.arrayBuffer();
-  const buffer = Buffer.from(binary);
-
-  //Sharpによる画像処理
-  const output = await sharp(buffer)
-    .rotate()
-    .resize(1200, null, { withoutEnlargement: true, fit: "inside" })
-    .webp({ quality: 80 })
-    .toFile(cover);
-
-  return {
-    url: `/${id}/${name}.webp`,
-    width: output.width,
-    height: output.height,
-  };
 };
 
 export default cacheRemoteImage;

--- a/src/utils/createOGPImage.tsx
+++ b/src/utils/createOGPImage.tsx
@@ -10,83 +10,91 @@ const createOGPImage = async function (
   writerName: string,
   lastEditTime: string,
 ) {
-  const regularFont = fs.readFileSync("public/ZenKakuGothicNew-Regular.ttf");
-  const boldFont = fs.readFileSync("public/ZenKakuGothicNew-Bold.ttf");
-
   const path = `public/${id}/`;
   const cover = `${path}ogp.png`;
   const result = `/${id}/ogp.png`;
 
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path);
-  }
+  try {
+    const regularFont = fs.readFileSync("public/ZenKakuGothicNew-Regular.ttf");
+    const boldFont = fs.readFileSync("public/ZenKakuGothicNew-Bold.ttf");
 
-  if (fs.existsSync(cover)) {
-    const stats = fs.statSync(cover);
-    const fileUpdateTime = new Date(stats.mtime).getTime();
-    const notionUpdateTime = new Date(lastEditTime).getTime();
-
-    // ファイルの更新時間よりも、Notionの更新時間の方が新しい場合のみ、以降の生成処理に進む
-    if (fileUpdateTime > notionUpdateTime) {
-      return result;
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path);
     }
-  }
 
-  const svg = await satori(
-    <div
-      style={{
-        display: "flex",
-        height: "100%",
-        width: "100%",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundImage: "linear-gradient(90deg, #FFC121, #FF5E2C)",
-        fontFamily: "Zen Kaku Gothic New",
-      }}
-    >
+    if (fs.existsSync(cover)) {
+      const stats = fs.statSync(cover);
+      const fileUpdateTime = new Date(stats.mtime).getTime();
+      const notionUpdateTime = new Date(lastEditTime).getTime();
+
+      // ファイルの更新時間よりも、Notionの更新時間の方が新しい場合のみ、以降の生成処理に進む
+      if (fileUpdateTime > notionUpdateTime) {
+        return result;
+      }
+    }
+
+    const svg = await satori(
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
+          height: "100%",
+          width: "100%",
           alignItems: "center",
           justifyContent: "center",
-          borderRadius: "8px",
-          gap: "24px",
-          backgroundColor: "#FFFCF2",
-          color: "#484335",
-          width: "90%",
-          height: "85%",
-          padding: "32px 64px",
+          backgroundImage: "linear-gradient(90deg, #FFC121, #FF5E2C)",
+          fontFamily: "Zen Kaku Gothic New",
         }}
       >
-        <div style={{ display: "flex", fontSize: "48px", fontWeight: 700 }}>{title}</div>
-        <div style={{ display: "flex", fontSize: "40px", fontWeight: 400 }}>@{writerName}</div>
-      </div>
-    </div>,
-    {
-      width: 1200,
-      height: 630,
-      fonts: [
-        {
-          name: "Zen Kaku Gothic New",
-          data: regularFont,
-          weight: 400,
-          style: "normal",
-        },
-        {
-          name: "Zen Kaku Gothic New",
-          data: boldFont,
-          weight: 700,
-          style: "normal",
-        },
-      ],
-    },
-  );
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "8px",
+            gap: "24px",
+            backgroundColor: "#FFFCF2",
+            color: "#484335",
+            width: "90%",
+            height: "85%",
+            padding: "32px 64px",
+          }}
+        >
+          <div style={{ display: "flex", fontSize: "48px", fontWeight: 700 }}>{title}</div>
+          <div style={{ display: "flex", fontSize: "40px", fontWeight: 400 }}>@{writerName}</div>
+        </div>
+      </div>,
+      {
+        width: 1200,
+        height: 630,
+        fonts: [
+          {
+            name: "Zen Kaku Gothic New",
+            data: regularFont,
+            weight: 400,
+            style: "normal",
+          },
+          {
+            name: "Zen Kaku Gothic New",
+            data: boldFont,
+            weight: 700,
+            style: "normal",
+          },
+        ],
+      },
+    );
 
-  // ogp画像ではsvgが使えないため、pngに変換する。
-  const pngData = await sharp(Buffer.from(svg)).png().toBuffer();
-  fs.writeFileSync(cover, pngData);
-  return result;
+    // ogp画像ではsvgが使えないため、pngに変換する。
+    const pngData = await sharp(Buffer.from(svg)).png().toBuffer();
+    fs.writeFileSync(cover, pngData);
+    return result;
+  } catch (error) {
+    // fallback: 'blocking' によりリクエスト時(サーバーレス環境)で実行された場合、
+    // public/ 配下のフォント読み込みや画像書き込みに失敗する。
+    // その場合はビルド時に生成済みの画像パスをそのまま返す(CDNから配信される)。
+    console.warn(`createOGPImage: OGP画像を生成できなかったため既存パスを返します (${id})`, error);
+    return result;
+  }
 };
 
 export default createOGPImage;


### PR DESCRIPTION
## 関連issue

なし（`fallback: 'blocking'` でNotion API呼び出しを削減する依頼）

## やったこと

### 背景・課題
ブログの動的ルート（`blog/[id]` / `blog/tag/[tag]` / `blog/writer/[writer]`）が `getStaticPaths` で**全パスを事前生成**しており、記事数に比例してNotion APIを大量に呼び出していました。特に `blog/[id]` は記事ごとに `getBlocks` / `getPage` / `getArticles`（おすすめ用にDB全件クエリ）を実行します。さらに `.github/workflows/build.yml` で**6時間ごとに全ビルド**が走るため、この呼び出しが繰り返されていました。

### 変更内容
- **動的ルートを `fallback: 'blocking'` 化**：`getStaticPaths` を `{ paths: [], fallback: "blocking" }` に変更。ビルド時の事前生成をやめ、リクエスト時にオンデマンド生成 → ISR（`revalidate: 3600` = 1時間）でキャッシュ。tag / writer の `getStaticPaths` から不要になった `getDatabase` 呼び出しも削除。
- **`blog/[id]` の重複クエリ削減**：公開記事一覧（`getArticles()`）を「記事の存在確認」と「おすすめ記事」で使い回し、重複していた `getArticles` 呼び出しを1回に集約。`fallback: 'blocking'` では任意のIDでアクセスされ得るため、公開記事に含まれないID（非公開・存在しない・公開日前）は `notFound` で404に。
- **tag / writer の404対応**：公開記事が0件のタグ/ライター（存在しない値への直接アクセス等）は404を返すように。
- **静的ページのISR化**：Notionを参照する `top` / `products` / `achievements` / `blog`(一覧) にも `revalidate` を付与。
- **画像ユーティリティのガード**：`fallback: 'blocking'` では `getStaticProps` がリクエスト時（Vercelのサーバーレス＝読み取り専用FS）で実行され、`public/` への書き込みやフォント読み込みに失敗します。`createOGPImage` / `cacheRemoteImage` のファイル操作を `try/catch` で保護し、失敗時はビルド時生成物のパス（CDN配信）／元のNotion URLにフォールバックしてページ生成を継続するようにしました。`revalidate` を1時間にしているのはNotion画像URLの有効期限（約1時間）と揃える意図もあります。
- `revalidate` の値は `src/constants/index.ts` の `ISR_REVALIDATE_SECONDS` に集約。

### 効果
- 通常ビルドで生成するのは静的ページ＋動的ルートの雛形のみになり、**ビルドごとのNotion API呼び出しが大幅に削減**されます（記事数 × 数回 → 数回程度）。
- 記事詳細はオンデマンド生成＋1時間キャッシュ。新規記事もリビルドを待たずに到達可能になります。

### 確認事項 / レビュー観点
- ✅ `tsc --noEmit` / `next lint` ともにエラーなし。
- ⚠️ 実行時（サーバーレス）の画像挙動は**Vercelのプレビューデプロイで確認**をお願いします。特に「前回ビルド以降に追加された新規記事の本文中画像／OGP」が、次回ビルドまでの間どう表示されるか（元URLフォールバック or 一時的に未表示）。
- 💬 `revalidate` の間隔（現状1時間）は運用に合わせて調整可能です。`ISR_REVALIDATE_SECONDS` 一箇所で変更できます。
- 補足: `.prettierrc.js` の `parser: "typescript" | "scss"` は不正値（JS評価で `0`）になっており `prettier` がエラーになります。本PRの対象外のため未修正ですが、別途修正推奨です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)